### PR TITLE
Update gulpfile and ignore compiled CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules
 
 # Ignore .DS_Store files on OS X
 .DS_Store
+
+# Compiled CSS file
+public/styles/site.css

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,4 +51,4 @@ gulp.task('watch', [
   'watch:lint'
 ]);
 
-gulp.task('default', ['watch', 'runKeystone']);
+gulp.task('default', ['stylus', 'watch', 'runKeystone']);


### PR DESCRIPTION
When starting gulp it compiles the stylus code, which means new devs dont have to change any stylus code to get the compiled styles.

Ref: https://github.com/nodejs/nodejs.org/issues/581#issuecomment-199554147
